### PR TITLE
Updated license badge image src in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Here's the generated file for the example from above
 [npm-downloads-href]: https://npmjs.com/package/@chronicstone/typed-xlsx
 [bundle-src]: https://img.shields.io/bundlephobia/minzip/@chronicstone/typed-xlsx?style=flat&colorA=080f12&colorB=1fa669&label=minzip
 [bundle-href]: https://bundlephobia.com/result?p=@chronicstone/typed-xlsx
-[license-src]: https://img.shields.io/github/ChronicStone/typed-xlsx.svg?style=flat&colorA=080f12&colorB=1fa669
+[license-src]: https://img.shields.io/github/license/ChronicStone/typed-xlsx.svg?style=flat&colorA=080f12&colorB=1fa669
 [license-href]: https://github.com/ChronicStone/typed-xlsx/blob/main/LICENSE
 [jsdocs-src]: https://img.shields.io/badge/jsdocs-reference-080f12?style=flat&colorA=080f12&colorB=1fa669
 [jsdocs-href]: https://www.jsdocs.io/package/@chronicstone/typed-xlsx


### PR DESCRIPTION
### **User description**
This commit fixes the image src for the license badge.


___

### **Description**
- Updated the license badge image src in the README.md file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Updated license badge image src in README.md</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md
['Updated the license badge image src in the README.md file.']


</details>


  </td>
  <td><a href="https://github.com/ChronicStone/typed-xlsx/pull/8/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>