### PR TITLE
fix(core): apply column formatters to cells

### DIFF
--- a/.changeset/fix-column-formatters.md
+++ b/.changeset/fix-column-formatters.md
@@ -1,0 +1,5 @@
+---
+"typed-xlsx": patch
+---
+
+Fix column format definitions so buffered and streamed workbooks apply number formats alongside static and dynamic cell styles.

--- a/packages/core/src/ooxml/worksheet.ts
+++ b/packages/core/src/ooxml/worksheet.ts
@@ -3,7 +3,7 @@ import {
   type BufferedSheetPlan,
   type BufferedTablePlan,
 } from "../workbook/types";
-import type { PlannedCell, ResolvedColumn } from "../planner/rows";
+import { resolveColumnCellStyle, type PlannedCell, type ResolvedColumn } from "../planner/rows";
 import type { CellStyle } from "../styles/types";
 import { StylesCollector } from "../styles/collector";
 import { serializeCell, toCellRef } from "./cells";
@@ -490,22 +490,15 @@ function resolveDataCellStyle<T extends object>(
   column: ResolvedColumn<T> | undefined,
   cell: PlannedCell<T>,
 ): CellStyle | undefined {
-  if (!column?.style) return undefined;
-  if (typeof column.style === "function") {
-    const styleFn = column.style as (...args: any[]) => CellStyle | undefined;
-    if (styleFn.length >= 3) {
-      return styleFn(cell.sourceRow, cell.sourceRowIndex, cell.subRowIndex);
-    }
+  if (!column) return undefined;
 
-    return styleFn({
-      ...cell.sourceRow,
-      ctx: undefined as never,
-      row: cell.sourceRow,
-      rowIndex: cell.sourceRowIndex,
-      subRowIndex: cell.subRowIndex,
-    } as never);
-  }
-  return column.style;
+  return resolveColumnCellStyle({
+    column,
+    ctx: undefined,
+    row: cell.sourceRow,
+    rowIndex: cell.sourceRowIndex,
+    subRowIndex: cell.subRowIndex,
+  });
 }
 
 function buildWorksheetColumns(

--- a/packages/core/src/planner/rows.ts
+++ b/packages/core/src/planner/rows.ts
@@ -196,6 +196,68 @@ function invokeRowStyle<T extends object>(params: {
   });
 }
 
+function invokeRowFormat<T extends object>(params: {
+  format: Extract<NonNullable<ResolvedColumn<T>["format"]>, (...args: any[]) => unknown>;
+  row: T;
+  rowIndex: number;
+  subRowIndex: number;
+  ctx?: SchemaContext;
+}) {
+  if (params.format.length >= 3) {
+    return (params.format as (row: T, rowIndex: number, subRowIndex: number) => string | undefined)(
+      params.row,
+      params.rowIndex,
+      params.subRowIndex,
+    );
+  }
+
+  return (params.format as (context: unknown) => string | undefined)({
+    ...params.row,
+    ctx: params.ctx,
+    row: params.row,
+    rowIndex: params.rowIndex,
+    subRowIndex: params.subRowIndex,
+  });
+}
+
+export function resolveColumnCellStyle<T extends object>(params: {
+  column: ResolvedColumn<T>;
+  row: T;
+  rowIndex: number;
+  subRowIndex: number;
+  ctx?: SchemaContext;
+}): CellStyle | undefined {
+  const baseStyle =
+    typeof params.column.style === "function"
+      ? invokeRowStyle({
+          ctx: params.ctx,
+          row: params.row,
+          rowIndex: params.rowIndex,
+          style: params.column.style,
+          subRowIndex: params.subRowIndex,
+        })
+      : params.column.style;
+  const numberFormat =
+    typeof params.column.format === "function"
+      ? invokeRowFormat({
+          ctx: params.ctx,
+          format: params.column.format,
+          row: params.row,
+          rowIndex: params.rowIndex,
+          subRowIndex: params.subRowIndex,
+        })
+      : params.column.format;
+
+  if (!baseStyle && !numberFormat) {
+    return undefined;
+  }
+
+  return {
+    ...(baseStyle ?? {}),
+    ...(numberFormat ? { numFmt: numberFormat } : {}),
+  };
+}
+
 function invokeRowHyperlink<T extends object>(params: {
   hyperlink: Extract<NonNullable<ResolvedColumn<T>["hyperlink"]>, (...args: any[]) => unknown>;
   row: T;
@@ -772,19 +834,15 @@ export function planRows<T extends object>(
     });
 
     for (let subRowIndex = 0; subRowIndex < rowHeight; subRowIndex++) {
-      const rowStyles: Array<CellStyle | undefined> = expandedCells.map((cell) => {
-        if (!cell.column.style) return undefined;
-        if (typeof cell.column.style === "function") {
-          return invokeRowStyle({
-            ctx: undefined,
-            row,
-            rowIndex: logicalRowIndex,
-            style: cell.column.style,
-            subRowIndex,
-          });
-        }
-        return cell.column.style;
-      });
+      const rowStyles: Array<CellStyle | undefined> = expandedCells.map((cell) =>
+        resolveColumnCellStyle({
+          column: cell.column,
+          ctx: undefined,
+          row,
+          rowIndex: logicalRowIndex,
+          subRowIndex,
+        }),
+      );
       const rowValues = expandedCells.map((cell) =>
         getCellPrimitiveValue(cell.values[subRowIndex] ?? null),
       );

--- a/packages/core/src/stream/rows.ts
+++ b/packages/core/src/stream/rows.ts
@@ -1,4 +1,4 @@
-import type { ResolvedColumn } from "../planner/rows";
+import { resolveColumnCellStyle, type ResolvedColumn } from "../planner/rows";
 import type { PrimitiveCellValue } from "../schema/builder";
 import type { SharedStringsCollector } from "../ooxml/shared-strings";
 import { serializeCell, serializeInlineStringCell } from "../ooxml/cells";
@@ -50,27 +50,6 @@ function invokeRowTransform<T extends object>(params: {
     row: params.row,
     rowIndex: params.rowIndex,
     value: params.value,
-  });
-}
-
-function invokeRowStyle<T extends object>(params: {
-  style: Extract<NonNullable<ResolvedColumn<T>["style"]>, (...args: any[]) => unknown>;
-  row: T;
-  rowIndex: number;
-  subRowIndex: number;
-}) {
-  if (params.style.length >= 3) {
-    return (
-      params.style as (row: T, rowIndex: number, subRowIndex: number) => CellStyle | undefined
-    )(params.row, params.rowIndex, params.subRowIndex);
-  }
-
-  return (params.style as (context: unknown) => CellStyle | undefined)({
-    ...params.row,
-    ctx: undefined,
-    row: params.row,
-    rowIndex: params.rowIndex,
-    subRowIndex: params.subRowIndex,
   });
 }
 
@@ -586,9 +565,11 @@ function resolveColumnStyle<T extends object>(
   rowIndex: number,
   subRowIndex: number,
 ): CellStyle | undefined {
-  if (!column.style) return undefined;
-  if (typeof column.style === "function") {
-    return invokeRowStyle({ row, rowIndex, style: column.style, subRowIndex });
-  }
-  return column.style;
+  return resolveColumnCellStyle({
+    column,
+    ctx: undefined,
+    row,
+    rowIndex,
+    subRowIndex,
+  });
 }

--- a/packages/core/src/workbook/stream.ts
+++ b/packages/core/src/workbook/stream.ts
@@ -1,4 +1,9 @@
-import { createPlannerStats, createSummaryBindings, resolveColumns } from "../planner/rows";
+import {
+  createPlannerStats,
+  createSummaryBindings,
+  resolveColumnCellStyle,
+  resolveColumns,
+} from "../planner/rows";
 import { buildWorksheetConditionalFormatting } from "../styles/conditional-runtime";
 import { buildWorksheetDataValidations } from "../validation/runtime";
 import { writeSharedStringsXml, createSharedStringsCollector } from "../ooxml/shared-strings";
@@ -1353,16 +1358,13 @@ function resolveColumnStyle<T extends object>(
   rowIndex: number,
   subRowIndex: number,
 ): CellStyle | undefined {
-  if (!column.style) return undefined;
-  if (typeof column.style === "function") {
-    const styleFn = column.style as (...args: any[]) => CellStyle | undefined;
-    if (styleFn.length >= 3) {
-      return styleFn(row, rowIndex, subRowIndex);
-    }
-
-    return styleFn({ ...row, ctx: undefined as never, row, rowIndex, subRowIndex } as never);
-  }
-  return column.style;
+  return resolveColumnCellStyle({
+    column,
+    ctx: undefined,
+    row,
+    rowIndex,
+    subRowIndex,
+  });
 }
 
 function toWorksheetCol(column: number) {

--- a/packages/core/test/ooxml.test.ts
+++ b/packages/core/test/ooxml.test.ts
@@ -1427,6 +1427,42 @@ describe("ooxml", () => {
     expect(stylesPart?.xml).toContain('formatCode="0.00&quot;%&quot;"');
   });
 
+  it("applies column format definitions alongside dynamic cell styles", () => {
+    const schema = Internal.SchemaBuilder.create<{ amount: number; completion: number }>()
+      .column("amount", {
+        accessor: "amount",
+        format: "$#,##0.00",
+      })
+      .column("completion", {
+        accessor: "completion",
+        format: ({ completion }) => (completion >= 0.8 ? "0.0%" : "0%"),
+        style: ({ completion }) => ({
+          fill: {
+            color: {
+              rgb: completion >= 0.8 ? "C6EFCE" : "FFC7CE",
+            },
+          },
+        }),
+      })
+      .build();
+
+    const workbook = Internal.BufferedWorkbookBuilder.create();
+    workbook.sheet("Formats").table("formats", {
+      schema,
+      rows: [{ amount: 1234.5, completion: 0.875 }],
+    });
+
+    const xml = Internal.serializeBufferedWorkbookPlan(workbook.buildPlan());
+    const worksheetPart = xml.parts.find((part) => part.path === "xl/worksheets/sheet1.xml");
+    const stylesPart = xml.parts.find((part) => part.path === "xl/styles.xml");
+
+    expect(worksheetPart?.xml).toContain('<c r="A2" s="');
+    expect(worksheetPart?.xml).toContain('<c r="B2" s="');
+    expect(stylesPart?.xml).toContain('formatCode="$#,##0.00"');
+    expect(stylesPart?.xml).toContain('formatCode="0.0%"');
+    expect(stylesPart?.xml).toContain('rgb="FFC6EFCE"');
+  });
+
   it("writes multiple summary rows when a column defines multiple summaries", () => {
     const schema = Internal.SchemaBuilder.create<{ amount: number; label: string }>()
       .column("label", {

--- a/packages/core/test/stream.test.ts
+++ b/packages/core/test/stream.test.ts
@@ -143,6 +143,48 @@ describe("stream builder", () => {
     expect(content).toContain(' ht="');
   });
 
+  it("applies column format definitions to streamed cell styles", async () => {
+    const schema = Internal.SchemaBuilder.create<{ amount: number; completion: number }>()
+      .column("amount", {
+        accessor: "amount",
+        format: "$#,##0.00",
+      })
+      .column("completion", {
+        accessor: "completion",
+        format: "0.0%",
+        style: ({ completion }) => ({
+          fill: {
+            color: {
+              rgb: completion >= 0.8 ? "C6EFCE" : "FFC7CE",
+            },
+          },
+        }),
+      })
+      .build();
+
+    const sink = new MemoryWorkbookSink();
+    const spoolFactory = new MemorySpoolFactory();
+    const workbook = Internal.StreamWorkbookBuilder.create({ sink, spoolFactory });
+    const table = await workbook.sheet("Formats").table("formats", {
+      schema,
+    });
+
+    await table.commit({
+      rows: [{ amount: 1234.5, completion: 0.875 }],
+    });
+    await workbook.finish();
+
+    const entries = unzipWorkbookEntries(sink.toUint8Array());
+    const worksheet = entries.get("xl/worksheets/sheet1.xml");
+    const styles = entries.get("xl/styles.xml");
+
+    expect(worksheet).toContain('<c r="A2" s="');
+    expect(worksheet).toContain('<c r="B2" s="');
+    expect(styles).toContain('formatCode="$#,##0.00"');
+    expect(styles).toContain('formatCode="0.0%"');
+    expect(styles).toContain('rgb="FFC6EFCE"');
+  });
+
   it("writes native Excel table parts and worksheet relationships in streamed workbooks", async () => {
     const schema = Internal.ExcelTableSchemaBuilder.create<{ amount: number; id: string }>()
       .column("id", {


### PR DESCRIPTION
## Summary

- apply `column.format` as the emitted Excel number format for data cells
- share formatter/style resolution across buffered and streamed writers
- add buffered and streamed regression coverage for formats combined with dynamic styles
- add a patch changeset for `typed-xlsx`

## Root cause

`ColumnDefinition.format` survived schema normalization, but body cell serialization only read `column.style.numFmt`. Consumers using `format: "0.0%"` or formatter helpers therefore got unformatted values unless they manually placed the number format under `style.numFmt`.

## Validation

- `bun test packages/core/test/ooxml.test.ts packages/core/test/stream.test.ts`
- `bun --filter typed-xlsx typecheck`
- `bun --filter typed-xlsx test`
- `bunx turbo run check --filter=!typed-xlsx-benchmark`
- `bunx turbo run twoslash:verify --filter=typed-xlsx-docs`